### PR TITLE
Add workaround for updating default model metadata

### DIFF
--- a/src/curategpt/store/chromadb_adapter.py
+++ b/src/curategpt/store/chromadb_adapter.py
@@ -370,7 +370,9 @@ class ChromaDBAdapter(DBAdapter):
             if kwargs.get('model') is None:
                 kwargs['model'] = self.default_model
             if prev_model and kwargs.get('model') != prev_model:
-                if self.client.get_or_create_collection(name=collection_name).count() > 0:
+                if kwargs.get('model') == self.default_model: # We have a prev_model and don't need to update
+                    logger.info(f"Collection uses model {prev_model} and no new model was provided.")
+                elif self.client.get_or_create_collection(name=collection_name).count() > 0:
                     raise ValueError(f"Cannot change model from {prev_model} to {kwargs.get('model')}")
 
             # assign venomx to metadata object


### PR DESCRIPTION
This handles the case in which `prev_model` is set and the DB adapter (in this case, just for chromadb) tries to update it to the default value, which is not likely to be the "real" model.
It's more of a workaround than a permanent solution.