### PR TITLE
Fix issue with duplicate references in Alzheimers app

### DIFF
--- a/src/curategpt/agents/chat_agent.py
+++ b/src/curategpt/agents/chat_agent.py
@@ -34,9 +34,6 @@ class ChatResponse(BaseModel):
     formatted_body: str = None
     """Body formatted with markdown links to references."""
 
-    formatted_references: str = None
-    """References formatted as markdown for display."""
-
     references: Optional[Dict[str, Any]] = None
     """References for citations detected in response."""
 

--- a/src/curategpt/agents/chat_agent.py
+++ b/src/curategpt/agents/chat_agent.py
@@ -200,8 +200,8 @@ class ChatAgentAlz(BaseAgent):
         if hasattr(self.knowledge_source, 'name') and self.knowledge_source.name == 'paperqa':
             self.knowledge_source.settings.agent.agent_system_prompt = (
                 """You are a specialized AI assistant for biomedical researchers and clinicians focused on
-                Alzheimer's disease and related topics. I will ask a question and you will answer 
-                as best as possible, citing references. For any additional facts that you are 
+                Alzheimer's disease and related topics. I will ask a question and you will answer
+                as best as possible, citing references. For any additional facts that you are
                 sure of, but without a citation, write [?].
                 """)
 
@@ -324,8 +324,8 @@ class ChatAgentAlz(BaseAgent):
 
     @staticmethod
     def _format_paperqa_references(answer: str, contexts: list) -> tuple[str, dict]:
-        from collections import OrderedDict
         import re
+        from collections import OrderedDict
 
         formatted_body = answer
         doc_key_to_num = OrderedDict()

--- a/src/curategpt/agents/chat_agent.py
+++ b/src/curategpt/agents/chat_agent.py
@@ -238,7 +238,21 @@ class ChatAgentAlz(BaseAgent):
                 self._format_paperqa_references(response_text,
                                                 session.contexts))
 
-            formatted_refs = {k: yaml.dump(v, sort_keys=False) for k, v in references.items() if v}
+            # formatted_refs = {k: yaml.dump(v, sort_keys=False) for k, v in references.items() if v}
+
+            def drop_empty_fields(d: dict) -> dict:
+                return {k: v for k, v in d.items() if isinstance(v, str) and v.strip()}
+
+            formatted_refs = {
+                k: yaml.safe_dump(
+                    drop_empty_fields(v),
+                    sort_keys=False,
+                    allow_unicode=True,
+                    default_flow_style=False,
+                    width=80  # prevents line wrapping madness
+                )
+                for k, v in references.items()
+            }
 
             return ChatResponse(
                 body=response_text,
@@ -246,7 +260,7 @@ class ChatAgentAlz(BaseAgent):
                 prompt=prompt,
                 references=formatted_refs,
                 uncited_references={},
-                conversation_id=None,
+                conversation_id=conversation_id,
             )
 
         else:

--- a/src/curategpt/agents/chat_agent.py
+++ b/src/curategpt/agents/chat_agent.py
@@ -33,7 +33,7 @@ class ChatResponse(BaseModel):
 
     formatted_body: str = None
     """Body formatted with markdown links to references."""
-    
+
     formatted_references: str = None
     """References formatted as markdown for display."""
 
@@ -56,28 +56,28 @@ def format_reference_as_markdown(ref_num, ref_data):
     if isinstance(ref_data, str):
         # Handle old-style string references
         return f"### Reference {ref_num}\n{ref_data}"
-    
+
     # Handle structured references
     md = f"### Reference {ref_num}\n"
-    
+
     if "id" in ref_data and ref_data["id"]:
         md += f"**ID**: {ref_data['id']}\n\n"
-    
+
     if "title" in ref_data and ref_data["title"]:
         md += f"**Title**: {ref_data['title']}\n\n"
-    
+
     if "abstract" in ref_data and ref_data["abstract"]:
         md += f"**Abstract**: {ref_data['abstract']}\n\n"
-    
+
     if "citation" in ref_data and ref_data["citation"]:
         md += f"**Citation**: {ref_data['citation']}\n\n"
-    
+
     if "url" in ref_data and ref_data["url"]:
         md += f"**URL**: [{ref_data['url']}]({ref_data['url']})\n\n"
-        
+
     if "doi" in ref_data and ref_data["doi"]:
         md += f"**DOI**: {ref_data['doi']}\n\n"
-        
+
     return md.strip()
 
 
@@ -182,7 +182,7 @@ class ChatAgent(BaseAgent):
         uncited_references_dict = {
             ref: ref_obj for ref, ref_obj in references.items() if ref not in used_references
         }
-        
+
         # Create structured references when possible
         structured_references = {}
         for ref_num, ref_data in used_references_dict.items():
@@ -198,17 +198,17 @@ class ChatAgent(BaseAgent):
                     structured_references[ref_num] = ref_data
             else:
                 structured_references[ref_num] = ref_data
-                
+
         used_references_dict = structured_references
         formatted_text = replace_references_with_links(response_text)
-        
+
         # Format references as markdown
         formatted_refs = "\n\n".join([
-            format_reference_as_markdown(ref_num, ref_data) 
+            format_reference_as_markdown(ref_num, ref_data)
             for ref_num, ref_data in used_references_dict.items()
             if ref_num != "?"  # Skip placeholder references
         ])
-        
+
         return ChatResponse(
             body=response_text,
             formatted_body=formatted_text,
@@ -278,62 +278,30 @@ class ChatAgentAlz(BaseAgent):
         is_paperqa = hasattr(self.knowledge_source, 'name') and self.knowledge_source.name == 'paperqa'
 
         model = self.extractor.model
-
-        def _format_paperqa_references(answer: str, contexts: list) -> tuple[str, dict]:
-            from collections import OrderedDict
-            import re
-
-            formatted_body = answer
-            doc_key_to_num = OrderedDict()
-            references = {}
-
-            # Assign numbers to unique doc.key
-            for ctx in contexts:
-                doc = ctx.text.doc
-                if doc.key not in doc_key_to_num:
-                    doc_key_to_num[doc.key] = len(doc_key_to_num) + 1
-                    references[str(doc_key_to_num[doc.key])] = {
-                        "id": doc.key if hasattr(doc, 'key') else "",
-                        "title": doc.title if hasattr(doc, 'title') else "",
-                        "abstract": doc.text if hasattr(doc, 'text') else "",
-                        "citation": doc.citation if hasattr(doc, 'citation') else "",
-                        "url": doc.doi_url if hasattr(doc, 'doi_url') else "",
-                        "doi": doc.doi if hasattr(doc, 'doi') else ""
-                    }
-
-            used_pairs = set()
-            for ctx in contexts:
-                text_name = ctx.text.name.strip()  # e.g. melendez2024 pages 6–7
-                doc_key = ctx.text.doc.key
-                ref_num = doc_key_to_num[doc_key]
-                pages = text_name.split("pages")[
-                    -1].strip() if "pages" in text_name else None
-
-                if (text_name, ref_num, pages) in used_pairs:
-                    continue
-                used_pairs.add((text_name, ref_num, pages))
-
-                markdown_link = f"[{ref_num}](#ref-{ref_num})"
-                replacement = f"{markdown_link} (pages {pages})" if pages else markdown_link
-                formatted_body = re.sub(re.escape(text_name), replacement,
-                                        formatted_body)
-
-            return formatted_body, references
+        if conversation:
+            conversation.model = model
+            agent = conversation
+            conversation_id = conversation.id
+            logger.info(f"Conversation ID: {conversation_id}")
+        else:
+            agent = model
+            conversation_id = None
 
         # Replace this block in ChatAgentAlz.chat
         if is_paperqa:
             session = kb_results.session
             response_text = session.answer.strip()
             prompt = f"[PaperQA] Question: {session.question}"
-            formatted_body, references = _format_paperqa_references(response_text,
-                                                                    session.contexts)
+            formatted_body, references = (
+                self._format_paperqa_references(response_text,
+                                                session.contexts))
 
             # Format references as markdown
             formatted_refs = "\n\n".join([
-                format_reference_as_markdown(ref_num, ref_data) 
+                format_reference_as_markdown(ref_num, ref_data)
                 for ref_num, ref_data in references.items()
             ])
-            
+
             return ChatResponse(
                 body=response_text,
                 formatted_body=formatted_body,
@@ -350,88 +318,100 @@ class ChatAgentAlz(BaseAgent):
 
             # For other sources, we need to format the results and create a prompt
             while True:
+                i = 0
                 references = {}
                 texts = []
-                for i, result_tuple in enumerate(kb_results, start=1):
-                    # Extract the object from the standard tuple format (obj, distance, metadata)
-                    obj, _, _ = result_tuple
-
+                current_length = 0
+                for obj, _, _obj_meta in kb_results:
+                    i += 1
                     obj_text = yaml.dump({k: v for k, v in obj.items() if v}, sort_keys=False)
                     references[str(i)] = obj_text
                     texts.append(f"## Reference {i}\n{obj_text}")
-
-                prompt = (
-                    "You are a specialized AI assistant for biomedical researchers and clinicians focused on "
-                    "Alzheimer's disease and related topics. I will provide relevant background information, then ask "
-                    "a question. Use this context to provide evidence-based answers with proper scientific citations.\n"
-                )
-                prompt += "---\nBackground facts:\n" + "\n".join(texts) + "\n\n"
+                    current_length += len(obj_text)
+                model = self.extractor.model
+                prompt = "I will first give background facts, then ask a question. Use the background fact to answer\n"
+                prompt += "---\nBackground facts:\n"
+                prompt += "\n".join(texts)
+                prompt += "\n\n"
+                prompt += "I will ask a question and you will answer as best as possible, citing the references above.\n"
+                prompt += "Write references in square brackets, e.g. [1].\n"
                 prompt += (
-                    "I will ask a question and you will answer as best as possible, citing the references above.\n"
-                    "Write references in square brackets, e.g. [1]. For any additional facts without a citation, write [?].\n"
+                    "For additional facts you are sure of but a reference is not found, write [?].\n"
                 )
                 prompt += f"---\nHere is the Question: {query}.\n"
                 logger.debug(f"Candidate Prompt: {prompt}")
                 estimated_length = estimate_num_tokens([prompt])
-                logger.debug(f"Max tokens {model.model_id}: {max_tokens_by_model(model.model_id)}")
-
-                if estimated_length + 300 < max_tokens_by_model(model.model_id):
+                logger.debug(
+                    f"Max tokens {self.extractor.model.model_id}: {max_tokens_by_model(self.extractor.model.model_id)}"
+                )
+                # TODO: use a more precise estimate of the length
+                if estimated_length + 300 < max_tokens_by_model(self.extractor.model.model_id):
                     break
                 else:
-                    logger.debug("Prompt too long, removing least relevant result.")
+                    # remove least relevant
+                    logger.debug(f"Removing least relevant of {len(kb_results)}: {kb_results[-1]}")
                     if not kb_results:
                         raise ValueError(f"Prompt too long: {prompt}.")
                     kb_results.pop()
 
-            logger.info("Final prompt constructed for chat.")
-            if conversation:
-                conversation.model = model
-                agent = conversation
-                conversation_id = conversation.id
-                logger.info(f"Using conversation context with ID: {conversation_id}")
-            else:
-                agent = model
-                conversation_id = None
+            logger.info(f"Prompt: {prompt}")
 
             response = agent.prompt(prompt, system="You are a scientist assistant.")
             response_text = response.text()
             pattern = r"\[(\d+|\?)\]"
             used_references = re.findall(pattern, response_text)
             used_references_dict = {ref: references.get(ref, "NO REFERENCE") for ref in used_references}
-            uncited_references_dict = {ref: ref_obj for ref, ref_obj in references.items() if ref not in used_references}
-            
-            # Create structured references when possible
-            structured_references = {}
-            for ref_num, ref_data in used_references_dict.items():
-                if ref_num != "?" and isinstance(ref_data, str):
-                    # Try to parse the YAML string into structured data
-                    try:
-                        yaml_dict = yaml.safe_load(ref_data)
-                        if isinstance(yaml_dict, dict):
-                            structured_references[ref_num] = yaml_dict
-                        else:
-                            structured_references[ref_num] = ref_data
-                    except Exception:
-                        structured_references[ref_num] = ref_data
-                else:
-                    structured_references[ref_num] = ref_data
-                    
-            used_references_dict = structured_references
+            uncited_references_dict = {
+                ref: ref_obj for ref, ref_obj in references.items() if ref not in used_references
+            }
             formatted_text = replace_references_with_links(response_text)
-
-            # Format references as markdown
-            formatted_refs = "\n\n".join([
-                format_reference_as_markdown(ref_num, ref_data) 
-                for ref_num, ref_data in used_references_dict.items()
-                if ref_num != "?"  # Skip placeholder references
-            ])
-            
             return ChatResponse(
                 body=response_text,
                 formatted_body=formatted_text,
                 prompt=prompt,
                 references=used_references_dict,
-                formatted_references=formatted_refs,
                 uncited_references=uncited_references_dict,
                 conversation_id=conversation_id,
             )
+
+    @staticmethod
+    def _format_paperqa_references(answer: str, contexts: list) -> tuple[str, dict]:
+        from collections import OrderedDict
+        import re
+
+        formatted_body = answer
+        doc_key_to_num = OrderedDict()
+        references = {}
+
+        # Assign numbers to unique doc.key
+        for ctx in contexts:
+            doc = ctx.text.doc
+            if doc.key not in doc_key_to_num:
+                doc_key_to_num[doc.key] = len(doc_key_to_num) + 1
+                references[str(doc_key_to_num[doc.key])] = {
+                    "id": doc.key if hasattr(doc, 'key') else "",
+                    "title": doc.title if hasattr(doc, 'title') else "",
+                    "abstract": doc.text if hasattr(doc, 'text') else "",
+                    "citation": doc.citation if hasattr(doc, 'citation') else "",
+                    "url": doc.doi_url if hasattr(doc, 'doi_url') else "",
+                    "doi": doc.doi if hasattr(doc, 'doi') else ""
+                }
+
+        used_pairs = set()
+        for ctx in contexts:
+            text_name = ctx.text.name.strip()  # e.g. melendez2024 pages 6–7
+            doc_key = ctx.text.doc.key
+            ref_num = doc_key_to_num[doc_key]
+            pages = text_name.split("pages")[
+                -1].strip() if "pages" in text_name else None
+
+            if (text_name, ref_num, pages) in used_pairs:
+                continue
+            used_pairs.add((text_name, ref_num, pages))
+
+            markdown_link = f"[{ref_num}](#ref-{ref_num})"
+            replacement = f"{markdown_link} (pages {pages})" if pages else markdown_link
+            formatted_body = re.sub(re.escape(text_name), replacement,
+                                    formatted_body)
+
+        return formatted_body, references

--- a/src/curategpt/agents/chat_agent.py
+++ b/src/curategpt/agents/chat_agent.py
@@ -44,7 +44,7 @@ class ChatResponse(BaseModel):
 def replace_references_with_links(text):
     """Replace references with links."""
     pattern = r"\[(\d+)\]"
-    replacement = lambda m: f"[{m.group(1)}](#ref-{m.group(1)})"
+    def replacement(m): return f"[{m.group(1)}](#ref-{m.group(1)})"
     return re.sub(pattern, replacement, text)
 
 
@@ -85,7 +85,8 @@ class ChatAgent(BaseAgent):
                 self.extractor = self.knowledge_source.extractor
             else:
                 raise ValueError("Extractor must be set.")
-        logger.info(f"Chat: {query} on {self.knowledge_source} kwargs: {kwargs}, limit: {limit}")
+        logger.info(
+            f"Chat: {query} on {self.knowledge_source} kwargs: {kwargs}, limit: {limit}")
         if collection is None:
             collection = self.knowledge_source_collection
         kwargs["collection"] = collection
@@ -101,7 +102,8 @@ class ChatAgent(BaseAgent):
             current_length = 0
             for obj, _, _obj_meta in kb_results:
                 i += 1
-                obj_text = yaml.dump({k: v for k, v in obj.items() if v}, sort_keys=False)
+                obj_text = yaml.dump(
+                    {k: v for k, v in obj.items() if v}, sort_keys=False)
                 references[str(i)] = obj_text
                 texts.append(f"## Reference {i}\n{obj_text}")
                 current_length += len(obj_text)
@@ -126,7 +128,8 @@ class ChatAgent(BaseAgent):
                 break
             else:
                 # remove least relevant
-                logger.debug(f"Removing least relevant of {len(kb_results)}: {kb_results[-1]}")
+                logger.debug(
+                    f"Removing least relevant of {len(kb_results)}: {kb_results[-1]}")
                 if not kb_results:
                     raise ValueError(f"Prompt too long: {prompt}.")
                 kb_results.pop()
@@ -141,11 +144,13 @@ class ChatAgent(BaseAgent):
         else:
             agent = model
             conversation_id = None
-        response = agent.prompt(prompt, system="You are a scientist assistant.")
+        response = agent.prompt(
+            prompt, system="You are a scientist assistant.")
         response_text = response.text()
         pattern = r"\[(\d+|\?)\]"
         used_references = re.findall(pattern, response_text)
-        used_references_dict = {ref: references.get(ref, "NO REFERENCE") for ref in used_references}
+        used_references_dict = {ref: references.get(
+            ref, "NO REFERENCE") for ref in used_references}
         uncited_references_dict = {
             ref: ref_obj for ref, ref_obj in references.items() if ref not in used_references
         }
@@ -191,7 +196,8 @@ class ChatAgentAlz(BaseAgent):
             else:
                 raise ValueError("Extractor must be set.")
 
-        logger.info(f"Chat: {query} on {self.knowledge_source} with limit: {limit}")
+        logger.info(
+            f"Chat: {query} on {self.knowledge_source} with limit: {limit}")
         if collection is None:
             collection = self.knowledge_source_collection
         kwargs["collection"] = collection
@@ -215,7 +221,8 @@ class ChatAgentAlz(BaseAgent):
         )
 
         # Check if we're using PaperQA
-        is_paperqa = hasattr(self.knowledge_source, 'name') and self.knowledge_source.name == 'paperqa'
+        is_paperqa = hasattr(self.knowledge_source,
+                             'name') and self.knowledge_source.name == 'paperqa'
 
         model = self.extractor.model
         if conversation:
@@ -272,7 +279,8 @@ class ChatAgentAlz(BaseAgent):
                 current_length = 0
                 for obj, _, _obj_meta in kb_results:
                     i += 1
-                    obj_text = yaml.dump({k: v for k, v in obj.items() if v}, sort_keys=False)
+                    obj_text = yaml.dump(
+                        {k: v for k, v in obj.items() if v}, sort_keys=False)
                     references[str(i)] = obj_text
                     texts.append(f"## Reference {i}\n{obj_text}")
                     current_length += len(obj_text)
@@ -297,18 +305,21 @@ class ChatAgentAlz(BaseAgent):
                     break
                 else:
                     # remove least relevant
-                    logger.debug(f"Removing least relevant of {len(kb_results)}: {kb_results[-1]}")
+                    logger.debug(
+                        f"Removing least relevant of {len(kb_results)}: {kb_results[-1]}")
                     if not kb_results:
                         raise ValueError(f"Prompt too long: {prompt}.")
                     kb_results.pop()
 
             logger.info(f"Prompt: {prompt}")
 
-            response = agent.prompt(prompt, system="You are a scientist assistant.")
+            response = agent.prompt(
+                prompt, system="You are a scientist assistant.")
             response_text = response.text()
             pattern = r"\[(\d+)\]"
             used_references = re.findall(pattern, response_text)
-            used_references_dict = {ref: references.get(ref, "NO REFERENCE") for ref in used_references}
+            used_references_dict = {ref: references.get(
+                ref, "NO REFERENCE") for ref in used_references}
             uncited_references_dict = {
                 ref: ref_obj for ref, ref_obj in references.items() if ref not in used_references
             }

--- a/src/curategpt/app/app_alz.py
+++ b/src/curategpt/app/app_alz.py
@@ -245,20 +245,20 @@ if option == CHAT:
     if page_state.chat_response:
         response = page_state.chat_response
         st.markdown(response.formatted_body)
-        add_button = st.button("Add to your cart")
-        if add_button:
-            logger.error("Adding to cart")
-            cart.add(response)
-            st.write("Added to cart!")
+        # add_button = st.button("Add to your cart")
+        # if add_button:
+        #     logger.error("Adding to cart")
+        #     cart.add(response)
+        #     st.write("Added to cart!")
 
         st.markdown("## References")
         for ref, text in response.references.items():
             st.subheader(f"Reference {ref}", anchor=f"ref-{ref}")
             st.code(text, language="yaml")
-            if st.button(f"Add to cart {ref}"):
-                # TODO: unpack
-                cart.add({"text": text, "id": ref})
-                st.success("Document added to cart!")
+            # if st.button(f"Add to cart {ref}"):
+            #     # TODO: unpack
+            #     cart.add({"text": text, "id": ref})
+            #     st.success("Document added to cart!")
         if response.uncited_references:
             st.markdown("## Uncited references")
             st.caption(

--- a/src/curategpt/wrappers/paperqa/paperqawrapper.py
+++ b/src/curategpt/wrappers/paperqa/paperqawrapper.py
@@ -3,7 +3,7 @@ import logging
 import os
 from dataclasses import dataclass
 
-from paperqa import Docs, Settings
+from paperqa import Settings
 from paperqa.agents.main import agent_query
 from paperqa.agents.search import get_directory_index
 

--- a/src/curategpt/wrappers/paperqa/paperqawrapper.py
+++ b/src/curategpt/wrappers/paperqa/paperqawrapper.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass
-from pathlib import Path
 
 from paperqa import Docs, Settings
 from paperqa.agents.main import agent_query
@@ -56,88 +55,18 @@ class PaperQAWrapper(BaseWrapper):
 
   def search(self, query, limit=10, **kwargs):
       """Search for documents matching the query using PaperQA."""
-      print(f"Searching for: {query}")
+      logger.info(f"Searching for: {query}")
+
       async def _search():
           try:
-              response = await agent_query(
+            response = await agent_query(
                   query=query,
                   settings=self.settings
-              )
+            )
+            return response
 
-              print(f"Query response contains {len(response.session.contexts)} contexts")
-
-              results = []
-              for idx, context in enumerate(response.session.contexts[:limit]):
-                  # Create a result object that matches the standard format
-                  obj = {
-                      "id": f"paper_{idx}",
-                      "title": context.text.doc.docname,
-                      "abstract": context.context,
-                      "citation": (getattr(context.text.doc, "citation", None) or
-                               f"Document: {context.text.doc.docname}"),
-                  }
-
-                  # Calculate a pseudo-distance (lower is better, use rank position)
-                  # Normalize to be between 0-1 like other distance metrics
-                  distance = idx / (len(response.session.contexts) or 1)
-
-                  # Add metadata for consistency with other wrappers
-                  metadata = {
-                      "document": obj["abstract"],
-                      "paper_name": context.text.doc.docname
-                  }
-
-                  # Append as a tuple of (obj, distance, metadata)
-                  results.append((obj, distance, metadata))
-
-              return iter(results)
           except Exception as e:
-              self._fallback_search(query, limit)
-              print(f"Error with agent_query: {e}")
+              logger.error(f"Error with agent_query: {e}")
               raise e
 
       return asyncio.run(_search())
-
-  def _fallback_search(self, query, limit=10):
-      """Fallback search method when agent_query fails."""
-      try:
-          async def _direct_docs_search():
-              docs = Docs()
-              pdf_path = Path(self.settings.paper_directory)
-              pdf_files = list(pdf_path.glob("*.pdf"))
-
-              for pdf_file in pdf_files:
-                  await docs.aadd(str(pdf_file))
-
-              answer = await docs.aquery(query, settings=self.settings)
-
-              results = []
-              for idx, context in enumerate(answer.contexts[:limit]):
-                  # Create a result object that matches the standard format
-                  obj = {
-                      "id": f"paper_{idx}",
-                      "title": context.text.doc.docname,
-                      "abstract": context.context,
-                      "citation": (getattr(context.text.doc, "citation", None) or
-                              f"Document: {context.text.doc.docname}"),
-                  }
-
-                  # Calculate a pseudo-distance (lower is better, use rank position)
-                  # Normalize to be between 0-1 like other distance metrics
-                  distance = idx / (len(answer.contexts) or 1)
-
-                  # Add metadata for consistency with other wrappers
-                  metadata = {
-                      "document": obj["abstract"],
-                      "paper_name": context.text.doc.docname
-                  }
-
-                  # Append as a tuple of (obj, distance, metadata)
-                  results.append((obj, distance, metadata))
-
-              return iter(results)
-
-          return asyncio.run(_direct_docs_search())
-      except Exception as e:
-          print(f"Error in fallback search: {e}")
-          return iter([])

--- a/src/curategpt/wrappers/paperqa/paperqawrapper.py
+++ b/src/curategpt/wrappers/paperqa/paperqawrapper.py
@@ -11,62 +11,63 @@ from curategpt.wrappers.base_wrapper import BaseWrapper
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class PaperQAWrapper(BaseWrapper):
-  """
-  A wrapper for PaperQA to search Alzheimer's papers.
+    """
+    A wrapper for PaperQA to search Alzheimer's papers.
 
-  This wrapper uses PaperQA to search through a corpus of research papers.
-  It assumes papers have already been indexed using PaperQA's CLI tools.
-  """
+    This wrapper uses PaperQA to search through a corpus of research papers.
+    It assumes papers have already been indexed using PaperQA's CLI tools.
+    """
 
-  name = "paperqa"
+    name = "paperqa"
 
-  def __post_init__(self) -> None:
-      pqa_home = os.environ.get("PQA_HOME")
-      if not pqa_home:
-          raise ValueError("PQA_HOME environment variable is not set!")
-      self.settings = Settings(paper_directory=pqa_home)
-      self._ensure_index_exists()
+    def __post_init__(self) -> None:
+        pqa_home = os.environ.get("PQA_HOME")
+        if not pqa_home:
+            raise ValueError("PQA_HOME environment variable is not set!")
+        self.settings = Settings(paper_directory=pqa_home)
+        self._ensure_index_exists()
 
-  def _ensure_index_exists(self):
-      async def _check_and_build_index():
-          try:
-              # given we build with cli this should work
-              await get_directory_index(settings=self.settings, build=False)
-              print("Existing index found")
-              return True
-          except Exception as e:
-              if "was empty" in str(e):
-                  print("Index is empty, building now...")
-                  try:
-                      # Build the index
-                      await get_directory_index(settings=self.settings, build=True)
-                      print("Index built successfully")
-                      return True
-                  except Exception as build_err:
-                      print(f"Error building index: {build_err}")
-                      return False
-              else:
-                  print(f"Error accessing index: {e}")
-                  return False
+    def _ensure_index_exists(self):
+        async def _check_and_build_index():
+            try:
+                # given we build with cli this should work
+                await get_directory_index(settings=self.settings, build=False)
+                print("Existing index found")
+                return True
+            except Exception as e:
+                if "was empty" in str(e):
+                    print("Index is empty, building now...")
+                    try:
+                        # Build the index
+                        await get_directory_index(settings=self.settings, build=True)
+                        print("Index built successfully")
+                        return True
+                    except Exception as build_err:
+                        print(f"Error building index: {build_err}")
+                        return False
+                else:
+                    print(f"Error accessing index: {e}")
+                    return False
 
-      asyncio.run(_check_and_build_index())
+        asyncio.run(_check_and_build_index())
 
-  def search(self, query, limit=10, **kwargs):
-      """Search for documents matching the query using PaperQA."""
-      logger.info(f"Searching for: {query}")
+    def search(self, query, limit=10, **kwargs):
+        """Search for documents matching the query using PaperQA."""
+        logger.info(f"Searching for: {query}")
 
-      async def _search():
-          try:
-            response = await agent_query(
-                  query=query,
-                  settings=self.settings
-            )
-            return response
+        async def _search():
+            try:
+                response = await agent_query(
+                    query=query,
+                    settings=self.settings
+                )
+                return response
 
-          except Exception as e:
-              logger.error(f"Error with agent_query: {e}")
-              raise e
+            except Exception as e:
+                logger.error(f"Error with agent_query: {e}")
+                raise e
 
-      return asyncio.run(_search())
+        return asyncio.run(_search())


### PR DESCRIPTION
To address #141, and generally just tidy up Alz app chat UI:

- I've deduped references in Alz app per #141 

- I've refactored a bunch of things, but should only affect the app-alz / Alzheimers app. I changed the `search` fxn in `PaperQAWrapper` so that it returns the entirety of the paperqa results (which is a  _**very**_ rich structure full of really useful data)

- I also changed the `ChatAgentAlz` so that if it receives something from `PaperQAWrapper.search()`, it parses the result to give to the user instead of running on LLM on it again, which is a weird thing to do (my fault). 

- also set a sensible system prompt when running paperqa agent to get chat response


